### PR TITLE
    解决某些异常退出，导致pid文件未删除后无法restart问题；

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ Cron
 conf.d
 *.log
 logs
+.idea/*
 *.*~

--- a/src/Ypf/Swoole.php
+++ b/src/Ypf/Swoole.php
@@ -216,6 +216,9 @@ class Swoole extends Ypf {
 			$processName = sprintf($name, $worker_id);
 		}
 		\swoole_set_process_name($processName);
+
+		$pid = posix_getpid();
+		$this->cache->set("worker_son_{$pid}", $this->worker_pid);
 		return true;
 	}
 
@@ -248,14 +251,26 @@ class Swoole extends Ypf {
 	}
 
 	public function onWorkerStop(\swoole_http_server $server, $worker_id) {
+
+		$pid = posix_getpid();
+		$worker_son = $this->cache->get("worker_son_{$pid}");
+
+		if(is_array($worker_son) && !empty($worker_son)){
+			foreach ($worker_son as $son_pid) {
+				\swoole_process::kill($son_pid, 9);
+			}
+
+			$this->cache->del("worker_son_{$pid}");
+		}
+
 		return true;
 	}
 
 	public function onShutDown(\swoole_http_server $server) {
 		$this->worker_pid = $this->cache->get('worker_pid');
-		foreach ($this->worker_pid as $pid) {
-			\swoole_process::kill($pid, 9);
-		}
+//		foreach ($this->worker_pid as $pid) {
+//			\swoole_process::kill($pid, 9);
+//		}
 		$this->cache->del('worker_pid');
 		@unlink($this->pidFile);
 		return true;

--- a/src/Ypf/Swoole/Cmd.php
+++ b/src/Ypf/Swoole/Cmd.php
@@ -77,12 +77,13 @@ class Cmd {
 
 	public static function restart() {
 		self::stop();
+		$loop = 3;
 		while (is_file(self::$masterPidFile)) {
 			$masterPid = @file_get_contents(self::$masterPidFile);
-			if (self::$masterPid != $masterPid) {
+			if (self::$masterPid != $masterPid || $loop < 0) {
 				break;
 			}
-
+			$loop--;
 			usleep(200000);
 		}
 		echo "server restarting ..." . PHP_EOL;


### PR DESCRIPTION
```
解决worker进程被kill -15 后，worker进程下的子进程未退出的问题；
```
